### PR TITLE
Analpa 2709 frontend kontin yhteysongelma

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": true
-}

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -3,10 +3,14 @@ FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.23.2-alpine
 
 # Used by nginx
 ARG PROXY_URL
-ENV PROXY_URL=${PROXY_URL}
 RUN echo ${PROXY_URL}
 
 COPY ./build /var/www
-COPY ./nginx/nginx.conf.template /nginx.conf.template
-# envsubst to substitute ENV variables in config
-CMD ["/bin/sh" , "-c" , "envsubst < /nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+COPY ./nginx/nginx.conf.template /etc/nginx/nginx.conf
+
+# substitute proxy url in nginx conf at buildtime
+RUN sed -i 's|!PROXY_URL!|'${PROXY_URL}'|' /etc/nginx/nginx.conf
+
+# substitute nameserver url in nginx conf at runtime
+CMD [ "/bin/sh", "-c", "sed -i 's|!NAMESERVER!|'$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')'|' /etc/nginx/nginx.conf \
+  && exec nginx -g 'daemon off;'" ]

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -16,7 +16,8 @@ http {
     }
 
     resolver 169.254.169.253;
-    set $upstream ${PROXY_URL}
+    set $upstream ${PROXY_URL};
+
     location /tietokatalogi/rest {
       proxy_pass $upstream:8080;
       proxy_connect_timeout 300s;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -15,8 +15,11 @@ http {
       index index.html;
     }
 
+    resolver !NAMESERVER!;
+    set $upstream !PROXY_URL!;
+
     location /tietokatalogi/rest {
-      proxy_pass ${PROXY_URL}:8080;
+      proxy_pass $upstream:8080;
       proxy_connect_timeout 300s;
       proxy_send_timeout 300;
       proxy_read_timeout 300s;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -15,11 +15,8 @@ http {
       index index.html;
     }
 
-    resolver 169.254.169.253;
-    set $upstream ${PROXY_URL};
-
     location /tietokatalogi/rest {
-      proxy_pass $upstream:8080;
+      proxy_pass ${PROXY_URL}:8080;
       proxy_connect_timeout 300s;
       proxy_send_timeout 300;
       proxy_read_timeout 300s;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -15,8 +15,10 @@ http {
       index index.html;
     }
 
+    resolver 169.254.169.253;
+    set $upstream ${PROXY_URL}
     location /tietokatalogi/rest {
-      proxy_pass ${PROXY_URL}:8080;
+      proxy_pass $upstream:8080;
       proxy_connect_timeout 300s;
       proxy_send_timeout 300;
       proxy_read_timeout 300s;


### PR DESCRIPTION
Yritetään korjata frontend-kontin yhteysongelma oletuksella, että ongelma johtui nginx:n aws-ympäristössä cachettamista dns/ip-osoitteista.

Päivitetty skripti hakee kontista toimivan nimipalvelimen ja lisää sen nginx-confiin `resolver` configin kohdalle. Jatkossa nginx pitäisi osata kysyä ip-osoitteet tarvittaessa uudestaan (jos/kun aws muuttaa load balancerin osoitetta).

Tämä branchi on rebasettu dev-puolelta (koska piti jo testata testiympäristössä).

Testaus:
- kontti pyörii jo dev-ympäristössä virheettä
- varsinaisen tuotanto-ongelman suhteen luulisin että on vain pakko deployata tuotantoon ja katsoa katoavatko ongelmat