### PR TITLE
add proxy config to external api

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -24,5 +24,12 @@ http {
       proxy_send_timeout 300;
       proxy_read_timeout 300s;
     }
+
+    location /tietokatalogi/external {
+      proxy_pass $upstream:8080;
+      proxy_connect_timeout 300s;
+      proxy_send_timeout 300;
+      proxy_read_timeout 300s;
+    }
   }
 }


### PR DESCRIPTION
Ulkoiselta rajapinnalta puuttui proxy config nginx:n puolelta. Lisätään puuttuva config, joka on käytännössä kopio sisäisten rajapintojen proxysta. Tämän pitäisi korjata ulkoinen rajapinta.