### PR TITLE
Analpa 3539 fix local container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ ENV PROXY_URL=${PROXY_URL}
 RUN echo ${PROXY_URL}
 
 COPY ./build /var/www
-COPY ./nginx/nginx.conf.template /nginx.conf.template
-# envsubst to substitute ENV variables in config
-CMD ["/bin/sh" , "-c" , "envsubst < /nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+COPY ./nginx/nginx.conf.template /etc/nginx/nginx.conf
+
+# substitute proxy url in nginx conf at buildtime
+RUN sed -i 's|!PROXY_URL!|'${PROXY_URL}'|' /etc/nginx/nginx.conf
+
+# substitute nameserver url in nginx conf at runtime
+CMD [ "/bin/sh", "-c", "sed -i 's|!NAMESERVER!|'$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')'|' /etc/nginx/nginx.conf \
+  && exec nginx -g 'daemon off;'" ]

--- a/README.md
+++ b/README.md
@@ -6,33 +6,35 @@
 ## Frontend
 
 ## Node and npm versions
+
 Node: 14.21.3
 npm: 6.14.18
 
 ### With docker
 
 Build the project outside docker with `npm run build`.
+
 Build the container with
 
-```
-docker build -t tietokatalogi-frontend --build-arg PROXY_URL=< backend's url here, starting with http:// > .
+```shell
+docker build -t tietokatalogi-frontend --build-arg PROXY_URL=http://{backend container's name} .
 ```
 
 ..., where the backend's address is either http://localhost if running outside docker, or, if running with docker-compose, can be found with
 
-```
+```shell
 docker network inspect tietokatalogi-backend_default
 ```
 
 Run the container with
 
-```
+```shell
 docker-compose up
 ```
 
 When finished, run (from another terminal)
 
-```
+```shell
 docker-compose down
 ```
 
@@ -42,25 +44,25 @@ TODO: how to change package.json -> proxy config? Currently it's configured to w
 
 Install
 
-```
+```shell
 npm install
 ```
 
 Run
 
-```
+```shell
 npm start
 ```
 
 To specify the url path for backend (other than the default tietokatalogi/rest)
 
-```
+```shell
 export REACT_APP_BASE_REST_URL="<path>"
 ```
 
 Build frontend
 
-```
+```shell
 npm run build
 ```
 
@@ -69,6 +71,6 @@ npm run build
 Tests are configured to work with Jest.
 Run the tests with
 
-```
+```shell
 npm run test
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm: 6.14.18
 
 Build the project outside docker with `npm run build`.
 
-Start the backend container and note its name from `docker ps`. Build the container with
+Start the backend container and note its name from `docker ps` (probably "tietokatalogi-backend"). Build the container with
 
 ```shell
 docker build -t tietokatalogi-frontend --build-arg PROXY_URL=http://{backend container's name} .

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker-compose down
 
 ### Without docker
 
-TODO: how to change package.json -> proxy config? Currently it's configured to work inside the container only.
+TODO: how to proxy requests locally without nginx?
 
 Install
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ npm: 6.14.18
 
 Build the project outside docker with `npm run build`.
 
-Build the container with
+Start the backend container and note its name from `docker ps`. Build the container with
 
 ```shell
 docker build -t tietokatalogi-frontend --build-arg PROXY_URL=http://{backend container's name} .
-```
-
-..., where the backend's address is either http://localhost if running outside docker, or, if running with docker-compose, can be found with
-
-```shell
-docker network inspect tietokatalogi-backend_default
 ```
 
 Run the container with


### PR DESCRIPTION
Fix the local tietokatalogi frontend Dockerfile that didn't work with our updated nginx configs (that were changed in a bugfix).

Changes:
- made Dockerfile similar to Dockerfile.aws that is used on our aws side
- updated readme on how to run the local container

To test:
- Dockerfile looks similar to Dockefile.aws
- you can try to follow the readme instructions locally