### PR TITLE
Analpa 3365 fix container vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 #production environment
-FROM nginx:1.23.2-alpine
+FROM nginx:1.25.3-alpine
+
+RUN ["apk", "upgrade", "--no-cache"]
 
 # Used by nginx
 ARG PROXY_URL

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -1,5 +1,7 @@
 #production environment
-FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.23.2-alpine
+FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.25.3-alpine
+
+RUN ["apk", "upgrade", "--no-cache"]
 
 # Used by nginx
 ARG PROXY_URL


### PR DESCRIPTION
Basically the same as https://github.com/finnishtransportagency/vaylariski-frontend/pull/82 on vaylariski side.

Fix container vulnerabilities by doing the following changes in dockerfiles (both local Dockerfile and Dockerfile.aws):
- upgrade baseimage
- add apk upgrade statement
- pushed the new baseimage to our aws ecr so we can pull our mirrored version in Dockerfile.aws (as we did before with the previous baseimage version)

### How to test
- install `trivy`: https://github.com/aquasecurity/trivy
- (you can build and scan the dev branch's container here for comparison)
- checkout this branch
- build the frontend container
- scan the frontend container with `trivy image tietokatalogi-frontend` (you name may vary)
- the scan should reveal little to no vulnerabilities, no critical